### PR TITLE
Modify the name of "return" variable for mod_gearman task

### DIFF
--- a/tasks/mod_gearman.yml
+++ b/tasks/mod_gearman.yml
@@ -138,14 +138,14 @@
     body_format: json
     return_content: yes
     validate_certs: no
-  register: return
+  register: returnapi
   when: "'mod_gearman_server' in group_names"
 
 - name : display result
   debug:
-    msg: "{{ return.content }}"
+    msg: "{{ returnapi.content }}"
   when: "'mod_gearman_server' in group_names"
 
 - name: Fail if ERROR in the page content
   fail:
-  when: "'mod_gearman_server' in group_names and 'ERROR' in return.content"
+  when: "'mod_gearman_server' in group_names and 'ERROR' in returnapi.content"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23166349/70472194-fdb05b80-1ace-11ea-81b4-f1abe6ded13e.png)


The name for this variable is invalid, with an other name it's working.

Tested on : ansible 2.9.1