### PR TITLE
Add support for hostgroups when defined

### DIFF
--- a/templates/mod_gearman/module.conf.j2
+++ b/templates/mod_gearman/module.conf.j2
@@ -54,7 +54,7 @@ hosts=yes
 # queues. Either specify a comma seperated list or use
 # multiple lines.
 #hostgroups=name1
-hostgroups={{mod_gearman_hostgroups_queues}}
+{% if hostgroups is defined %}hostgroups={{ hostgroups }}{% else %}hostgroups={{mod_gearman_hostgroups_queues}}{% endif %}
 
 
 # sets a list of servicegroups which will go into seperate


### PR DESCRIPTION
When hostgroups are defined for the execution of the playbook, the variable "hostgroups" on this file is not set.
This is a fix.